### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ $ cmake ../
 ```
 make shall do:
 ```
-make
+make driver
 Scanning dependencies of target driver
 [100%] Generating hello.ko
 [100%] Built target driver


### PR DESCRIPTION
It should be called "make driver" instead of "make", because the last one causes error.